### PR TITLE
Modernize portfolio design

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -3,20 +3,26 @@
 @plugin '@tailwindcss/typography';
 
 @theme {
-	--bg: #f9fafb;
-	--fg: #111827;
-	--accent: #1d4ed8;
-	--muted: #6b7280;
-	--highlight: #0ea5e9;
-	--border: #e5e7eb;
-	--hero-headline: #0f172a;
-	--hero-subline: #334155;
+        --bg: #FAFAFA;
+        --fg: #1E1E1E;
+        --accent: #FFBC7B;
+        --muted: #6B7280;
+        --highlight: #D6F5E1;
+        --border: #E5E7EB;
+        --hero-headline: #4E536B;
+        --hero-subline: #4E536B;
 }
 
 @layer base {
-	html {
-		background-color: var(--bg);
-		color: var(--fg);
-		font-family: system-ui, sans-serif;
-	}
+       html {
+               background-color: var(--bg);
+               color: var(--fg);
+               font-family: 'Inter', sans-serif;
+       }
+       h1, h2, h3 {
+               font-family: 'Figtree', sans-serif;
+       }
+       code {
+               font-family: 'Fira Code', monospace;
+       }
 }

--- a/src/app.html
+++ b/src/app.html
@@ -3,8 +3,11 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		%sveltekit.head%
+               <meta name="viewport" content="width=device-width, initial-scale=1" />
+               <link rel="preconnect" href="https://fonts.googleapis.com" />
+               <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+               <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Figtree:wght@500;700&family=Fira+Code&display=swap" rel="stylesheet" />
+               %sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -13,11 +13,11 @@
 	};
 </script>
 
-<footer class="bg-gray-900 py-8 text-center text-sm text-white">
+<footer class="bg-fg py-8 text-center text-sm text-white">
 	<p>{$copyright}</p>
-	<div class="mt-4 flex justify-center gap-6">
-		{#each $links as label (label)}
-			<a href={linkMap[label]} class="hover:underline">{label}</a>
-		{/each}
-	</div>
+       <div class="mt-4 flex justify-center gap-6">
+               {#each $links as label (label)}
+                       <a href={linkMap[label]} class="text-highlight hover:text-accent transition-colors">{label}</a>
+               {/each}
+       </div>
 </footer>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -8,7 +8,7 @@
 	const setLang = (value: 'de' | 'en') => lang.set(value);
 </script>
 
-<header class="border-border w-full border-b bg-white">
+<header class="sticky top-0 z-50 w-full border-b border-border bg-white/90 backdrop-blur">
 	<div class="mx-auto max-w-screen-xl px-4 sm:px-6 md:px-8">
 		<div class="flex h-16 items-center justify-between">
 			<!-- Logo -->
@@ -19,44 +19,44 @@
 			<!-- Navigation -->
 			<nav class="hidden space-x-6 md:flex">
 				{#if $navigation}
-					<a
-						href="/"
-						class={`text-muted hover:text-fg transition-colors ${
-							$page.url.pathname === '/' ? 'text-fg font-semibold' : ''
-						}`}
-					>
+                                       <a
+                                                href="/"
+                                                class={`text-muted hover:text-fg transition-colors focus-visible:ring-2 focus-visible:ring-accent rounded ${
+                                                        $page.url.pathname === '/' ? 'text-fg font-semibold' : ''
+                                                }`}
+                                        >
 						{$navigation[0]}
 					</a>
-					<a
-						href="/about"
-						class={`text-muted hover:text-fg transition-colors ${
-							$page.url.pathname === '/about' ? 'text-fg font-semibold' : ''
-						}`}
-					>
+                                       <a
+                                                href="/about"
+                                                class={`text-muted hover:text-fg transition-colors focus-visible:ring-2 focus-visible:ring-accent rounded ${
+                                                        $page.url.pathname === '/about' ? 'text-fg font-semibold' : ''
+                                                }`}
+                                        >
 						{$navigation[1]}
 					</a>
-					<a
-						href="/projects"
-						class={`text-muted hover:text-fg transition-colors ${
-							$page.url.pathname === '/projects' ? 'text-fg font-semibold' : ''
-						}`}
-					>
+                                       <a
+                                                href="/projects"
+                                                class={`text-muted hover:text-fg transition-colors focus-visible:ring-2 focus-visible:ring-accent rounded ${
+                                                        $page.url.pathname === '/projects' ? 'text-fg font-semibold' : ''
+                                                }`}
+                                        >
 						{$navigation[2]}
 					</a>
-					<a
-						href="/services"
-						class={`text-muted hover:text-fg transition-colors ${
-							$page.url.pathname === '/services' ? 'text-fg font-semibold' : ''
-						}`}
-					>
+                                       <a
+                                                href="/services"
+                                                class={`text-muted hover:text-fg transition-colors focus-visible:ring-2 focus-visible:ring-accent rounded ${
+                                                        $page.url.pathname === '/services' ? 'text-fg font-semibold' : ''
+                                                }`}
+                                        >
 						{$navigation[3]}
 					</a>
-					<a
-						href="/contact"
-						class={`text-muted hover:text-fg transition-colors ${
-							$page.url.pathname === '/contact' ? 'text-fg font-semibold' : ''
-						}`}
-					>
+                                       <a
+                                                href="/contact"
+                                                class={`text-muted hover:text-fg transition-colors focus-visible:ring-2 focus-visible:ring-accent rounded ${
+                                                        $page.url.pathname === '/contact' ? 'text-fg font-semibold' : ''
+                                                }`}
+                                        >
 						{$navigation[4]}
 					</a>
 				{/if}
@@ -64,19 +64,19 @@
 
 			<!-- Language Switch -->
 			<div class="flex items-center space-x-3">
-				<button
-					on:click={() => setLang('de')}
-					class="text-muted hover:text-fg text-sm transition-colors"
-				>
-					DE
-				</button>
-				<span class="text-muted">|</span>
-				<button
-					on:click={() => setLang('en')}
-					class="text-muted hover:text-fg text-sm transition-colors"
-				>
-					EN
-				</button>
+                               <button
+                                       on:click={() => setLang('de')}
+                                       class="text-muted hover:text-fg text-sm transition-colors focus-visible:ring-2 focus-visible:ring-accent rounded"
+                               >
+                                       DE
+                               </button>
+                               <span class="text-muted">|</span>
+                               <button
+                                       on:click={() => setLang('en')}
+                                       class="text-muted hover:text-fg text-sm transition-colors focus-visible:ring-2 focus-visible:ring-accent rounded"
+                               >
+                                       EN
+                               </button>
 			</div>
 		</div>
 	</div>

--- a/src/lib/sections/AboutSection.svelte
+++ b/src/lib/sections/AboutSection.svelte
@@ -6,9 +6,12 @@
 	const text = getText('about', 'text');
 </script>
 
-<div class="bg-gray-50">
-	<SectionWrapper className="py-24 text-center">
-		<h2 class="text-3xl font-bold text-gray-900">{$headline}</h2>
-		<p class="mt-4 text-lg text-gray-600">{$text}</p>
-	</SectionWrapper>
+<div class="bg-white">
+       <SectionWrapper className="py-24 md:grid md:grid-cols-2 md:items-center md:gap-8">
+               <div class="mx-auto mb-8 h-40 w-40 rounded-full bg-gradient-to-tr from-highlight to-accent/40 md:mb-0" />
+               <div class="text-center md:text-left">
+                       <h2 class="text-3xl font-bold text-fg">{$headline}</h2>
+                       <p class="mt-4 text-lg text-muted">{$text}</p>
+               </div>
+       </SectionWrapper>
 </div>

--- a/src/lib/sections/ContactSection.svelte
+++ b/src/lib/sections/ContactSection.svelte
@@ -8,11 +8,11 @@
 </script>
 
 <div class="bg-white">
-	<SectionWrapper className="py-24 text-center">
-		<h2 class="text-3xl font-bold text-gray-900">{$headline}</h2>
-		<p class="mt-4 text-gray-600">{$description}</p>
-		<button class="mt-6 rounded-lg bg-black px-6 py-3 text-white hover:bg-gray-800">
-			{$button}
-		</button>
-	</SectionWrapper>
+       <SectionWrapper className="py-24 text-center">
+               <h2 class="text-3xl font-bold text-fg">{$headline}</h2>
+               <p class="mt-4 text-muted">{$description}</p>
+               <button class="mt-6 rounded-lg bg-accent px-6 py-3 text-white transition-transform hover:scale-105 hover:bg-accent/90 focus-visible:ring-2 focus-visible:ring-accent">
+                       {$button}
+               </button>
+       </SectionWrapper>
 </div>

--- a/src/lib/sections/HeroSection.svelte
+++ b/src/lib/sections/HeroSection.svelte
@@ -7,19 +7,19 @@
 	const cta = getText('hero', 'cta');
 </script>
 
-<div class="relative overflow-hidden bg-white">
-	<SectionWrapper className="py-24 text-center">
-		<h1 class="text-hero-headline text-4xl font-bold sm:text-5xl md:text-6xl">
+<div class="relative overflow-hidden bg-gradient-to-br from-bg via-highlight to-accent/30">
+       <SectionWrapper className="py-32 text-center">
+               <h1 class="text-hero-headline text-5xl font-bold sm:text-6xl md:text-7xl tracking-tight">
 			{$headline}
 		</h1>
 		<p class="text-hero-subline mx-auto mt-6 max-w-xl text-lg">
 			{$subline}
 		</p>
-		<div class="mt-10">
-			<a
-				href="#contact"
-				class="bg-accent hover:bg-accent/90 inline-block rounded-xl px-6 py-3 text-white transition-colors"
-			>
+               <div class="mt-10">
+                       <a
+                               href="#contact"
+                               class="bg-accent hover:bg-accent/90 inline-block rounded-xl px-8 py-4 text-white shadow-lg transition-transform hover:scale-105"
+                       >
 				{$cta}
 			</a>
 		</div>

--- a/src/lib/sections/ProjectsSection.svelte
+++ b/src/lib/sections/ProjectsSection.svelte
@@ -9,12 +9,12 @@
 </script>
 
 <div class="bg-gray-100">
-	<SectionWrapper className="py-24 text-center">
-		<h2 class="text-3xl font-bold text-gray-900">{$headline}</h2>
+       <SectionWrapper className="py-24 text-center">
+               <h2 class="text-3xl font-bold text-fg">{$headline}</h2>
 
-		<div class="mt-8 grid gap-8 md:grid-cols-2">
+               <div class="mt-8 grid gap-8 md:grid-cols-2">
 			{#each $items as item (item.title)}
-				<div class="rounded-xl bg-white p-6 text-left shadow-md">
+                               <div class="rounded-xl bg-white p-6 text-left shadow-md transition-transform hover:-translate-y-1 hover:shadow-lg">
 					<h3 class="text-xl font-semibold text-gray-800">{item.title}</h3>
 					<p class="mt-2 text-gray-600">{item.description}</p>
 				</div>

--- a/src/lib/sections/ServicesSection.svelte
+++ b/src/lib/sections/ServicesSection.svelte
@@ -7,9 +7,9 @@
 </script>
 
 <div class="bg-white">
-	<SectionWrapper className="py-24 text-center">
-		<h2 class="text-3xl font-bold text-gray-900">{$headline}</h2>
-		<ul class="mt-6 space-y-3 text-lg text-gray-700">
+       <SectionWrapper className="py-24 text-center">
+               <h2 class="text-3xl font-bold text-fg">{$headline}</h2>
+               <ul class="mt-6 space-y-3 text-lg text-muted list-disc list-inside">
 			{#each $items as item (item)}
 				<li>{item}</li>
 			{/each}

--- a/src/lib/sections/SkillsSection.svelte
+++ b/src/lib/sections/SkillsSection.svelte
@@ -8,35 +8,35 @@
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero.
 	</p>
 
-	<div class="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3">
+       <div class="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3">
 		<!-- Tech Skills -->
-		<div class="border-border rounded-2xl border bg-white p-6 shadow-sm">
+               <div class="border-border rounded-2xl border bg-white p-6 shadow-sm transition-transform hover:scale-105">
 			<h3 class="text-fg text-xl font-semibold">SvelteKit</h3>
 			<p class="text-muted mt-2 text-sm">Modernes Webframework mit Fokus auf Performance & DX.</p>
 		</div>
-		<div class="border-border rounded-2xl border bg-white p-6 shadow-sm">
+               <div class="border-border rounded-2xl border bg-white p-6 shadow-sm transition-transform hover:scale-105">
 			<h3 class="text-fg text-xl font-semibold">Tailwind CSS</h3>
 			<p class="text-muted mt-2 text-sm">
 				Utility-first CSS für perfekte Kontrolle und Skalierung.
 			</p>
 		</div>
-		<div class="border-border rounded-2xl border bg-white p-6 shadow-sm">
+               <div class="border-border rounded-2xl border bg-white p-6 shadow-sm transition-transform hover:scale-105">
 			<h3 class="text-fg text-xl font-semibold">Shopify (Theme)</h3>
 			<p class="text-muted mt-2 text-sm">Theme-Anpassung & Performance für E-Commerce-Projekte.</p>
 		</div>
 
 		<!-- Soft Skills -->
-		<div class="border-border rounded-2xl border bg-white p-6 shadow-sm">
+               <div class="border-border rounded-2xl border bg-white p-6 shadow-sm transition-transform hover:scale-105">
 			<h3 class="text-fg text-xl font-semibold">Technisches Denken</h3>
 			<p class="text-muted mt-2 text-sm">Ich erkenne Muster, baue stabil und denke in Modulen.</p>
 		</div>
-		<div class="border-border rounded-2xl border bg-white p-6 shadow-sm">
+               <div class="border-border rounded-2xl border bg-white p-6 shadow-sm transition-transform hover:scale-105">
 			<h3 class="text-fg text-xl font-semibold">Klarheit & Struktur</h3>
 			<p class="text-muted mt-2 text-sm">
 				Keine Effekthascherei – der Code bleibt lesbar und wartbar.
 			</p>
 		</div>
-		<div class="border-border rounded-2xl border bg-white p-6 shadow-sm">
+               <div class="border-border rounded-2xl border bg-white p-6 shadow-sm transition-transform hover:scale-105">
 			<h3 class="text-fg text-xl font-semibold">Verlässlichkeit</h3>
 			<p class="text-muted mt-2 text-sm">Ich halte Timings ein und arbeite lösungsorientiert.</p>
 		</div>


### PR DESCRIPTION
## Summary
- refresh color palette and font families
- embed Google fonts in `app.html`
- improve hero section styling and CTA
- redesign about, skills, projects, services and contact sections
- make header sticky and footer highlight links

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684976790034832d8c01bd78ee92abf3